### PR TITLE
Fix missing Font Awesome CSS on terms and privacy pages

### DIFF
--- a/public/privacy.html
+++ b/public/privacy.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Privacy Notice - Rhea Health</title>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
   <link rel="stylesheet" href="css/main.css">
 </head>
 <body>

--- a/public/terms.html
+++ b/public/terms.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Terms of Service - Rhea Health</title>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
   <link rel="stylesheet" href="css/main.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary

- `terms.html` and `privacy.html` were missing the Font Awesome stylesheet, causing the hamburger menu icon (`fas fa-bars`) in the shared header to render as a blank glyph on mobile (≤768px)
- Added `preconnect` hint and Font Awesome 6.5.2 CSS to both pages, matching the pattern in `screening.html` and `for_clinicians.html`

## Test plan

- [ ] Open `terms.html` on a mobile viewport (or DevTools ≤768px) — hamburger icon should be visible
- [ ] Open `privacy.html` on a mobile viewport — hamburger icon should be visible
- [ ] Tap hamburger on both pages — nav menu opens correctly
- [ ] Desktop layout unaffected

https://claude.ai/code/session_013jUs62FzYaBZqurg8LhMWq