### PR TITLE
Fix mobile hamburger menu not working on privacy.html

### DIFF
--- a/public/privacy.html
+++ b/public/privacy.html
@@ -83,5 +83,6 @@
       if (f) f.innerHTML = await fetch('footer.html').then(r=>r.text());
     })();
   </script>
+  <script src="js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- `privacy.html` was missing `<script src="js/main.js" defer></script>`
- `main.js` registers the burger menu click handler; without it the icon renders (Font Awesome is loaded) but tapping it does nothing on mobile
- `terms.html` already loads `main.js` correctly — this brings `privacy.html` in line

## Test plan

- [ ] Open `privacy.html` on a mobile viewport (≤768px) — tap hamburger icon, nav menu should open and close
- [ ] Desktop layout unaffected

https://claude.ai/code/session_013jUs62FzYaBZqurg8LhMWq